### PR TITLE
added pullback to main map, kept tiled map due to unwanted errors if not

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -192,7 +192,7 @@ function fetchGlobalTopTracks() {
         });
 }
 
-var worldjsonPath = "./assets/custom.geo.json"
+// var worldjsonPath = "./assets/custom.geo.json"
 // function getJSON(worldjsonPath) {
 //     fetch(worldjsonPath)
 //         .then(function (data) {
@@ -204,10 +204,16 @@ var worldjsonPath = "./assets/custom.geo.json"
 
 // getJSON(worldjsonPath);
 
-var map = L.map('map').setView([0, 0], 6);
+var map = L.map('map', {
+    center: [0, 0],
+    maxZoom: 4,
+});
+map.setMaxBounds([[-85.0511, -180], [85.0511, 180]]);
+map.fitWorld();
 map.createPane('labels');
 map.getPane('labels').style.zIndex = 650;//always in the front
 map.getPane('labels').style.pointerEvents = 'none';
+L.control.scale({ 'position': 'bottomleft', 'metric': true, 'imperial': false }).addTo(map);
 var countryName; //adding this so we can pass the city clicked to the fetch function
 // import { worldCountries } from "./custom.geo.js";
 // var worldGeoJSON = "./assets/custom.geo.json";
@@ -217,11 +223,19 @@ var countryName; //adding this so we can pass the city clicked to the fetch func
 //     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 // }).addTo(map);
 var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
-    attribution: '©OpenStreetMap, ©CartoDB'
+    attribution: '©OpenStreetMap, ©CartoDB',
+    continuousWorld: false,
+    // noWrap: true,
+    // Bounds: [[-85.0511, -180], [85.0511, 180]],
+    // maxZoom: 4
 }).addTo(map);
 
 var positronLabels = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png', {
     attribution: '©OpenStreetMap, ©CartoDB',
+    continuousWorld: false,
+    // noWrap: true,
+    // Bounds: [[-85.0511, -180], [85.0511, 180]],
+    // maxZoom: 4,
     pane: 'labels'
 }).addTo(map);
 
@@ -241,3 +255,4 @@ geojson.eachLayer(function (layer) {
 });
 
 map.fitBounds(geojson.getBounds());
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,5 +1,6 @@
 #map {
-    height: 500px;
+    height: 900px;
+    width: 100vw;
 }
 
 header {

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no"">
+    <link rel=" stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.2/dist/leaflet.css"
         integrity="sha256-sA+zWATbFveLLNqWO2gtiw3HL/lh1giY/Inf1BJ0z14=" crossorigin="" />
     <link rel="stylesheet" href="./assets/style.css" />


### PR DESCRIPTION
Now if you scroll past the world map it sorta just rubber band back onto the main one. I was able to get rid of the additional tile image, but the api is throwing an error trying to load outside of the bound, so I opted for it to still tile around (you can see the other continents overflowing) but it will always pull you back to the main map:

check slack for gif sample